### PR TITLE
handles items being undefined

### DIFF
--- a/lib/homeconnect_device.js
+++ b/lib/homeconnect_device.js
@@ -602,7 +602,7 @@ module.exports = class HomeConnectDevice extends EventEmitter {
 
     // Process received events
     async eventListener(event) {
-        let itemCount = event.data ? event.data.items.length : 0;
+        let itemCount = event.data ? ( event.data.items ? ( event.data.items.length ? event.data.items.length :0 ) : 0) : 0;
         this.log('Event ' + event.event + ' (' + itemCount
                  + (itemCount == 1 ? ' item)' : ' items)'));
         switch (event.event) {


### PR DESCRIPTION
Hey,

not sure, when it started and if it happens "all the time", but I do see very often

```
[13.5.2022, 11:39:00] TypeError: Cannot read properties of undefined (reading 'length')
    at HomeConnectDevice.eventListener (/usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_device.js:605:55)
    at HomeConnectAPI.HomeConnectDevice.listener (/usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_device.js:40:39)
    at HomeConnectAPI.emit (node:events:520:28)
    at Object.dispatch (/usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_api.js:746:51)
    at /usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_api.js:811:27
    at Array.forEach (<anonymous>)
    at HomeConnectAPI.eventChunk (/usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_api.js:796:30)
    at BodyReadable.<anonymous> (/usr/local/lib/node_modules/homebridge-homeconnect/lib/homeconnect_api.js:780:49)
    at BodyReadable.emit (node:events:520:28)
    at BodyReadable.emit (/usr/local/lib/node_modules/homebridge-homeconnect/node_modules/undici/lib/api/readable.js:66:18)
```

followed by a `Got SIGTERM, shutting down Homebridge...` 

Since I changed it, the error does not occour anymore. 

As said - maybe something else is wrong and if that's just a temporary error. Maybe you could have a look?

Thanks in advance