### PR TITLE
Add additional setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Home Connect home appliances plugin for [Homebridge](https://github.com/nfarina/
 1. If you are using a legacy Home Connect account then also create a [SingleKey ID](https://singlekey-id.com/en/sign-up/) using the same email address, ensuring that it is all in lowercase.
 1. Obtain a Home Connect application *Client ID*:
    1. Sign-up for a free [Home Connect Developer Program](https://developer.home-connect.com/user/register) account and login.
-   1. [Register a new application](https://developer.home-connect.com/applications/add), ensuring that the *OAuth Flow* is set to *Device Flow*, and the *Home Connect User Account* is the same as the SingleKey ID email address.
+   1. [Register a new application](https://developer.home-connect.com/applications/add), ensuring that:
+      1.  *OAuth Flow* is set to *Device Flow*
+      1.  *Home Connect User Account* is the same as the SingleKey ID email address
+      1.  *Redirect URI* is not empty (you could set to `http://homebridge.local/plugins`)
    1. Save the displayed *Client ID* to include in the Homebridge `config.json` file.
 1. Install this plugin using: `npm install -g homebridge-homeconnect`
 1. Edit `config.json` and add the HomeConnect platform (see example below).


### PR DESCRIPTION
When I tried setting up the plugin with a new home connect application, it wasn't working. When I set a redirect URI it started working. This updates the instructions to add that step